### PR TITLE
Fixed: 1. if URL contains un-replaced variables, stop process, ask for

### DIFF
--- a/src/main/java/com/compuware/ispw/restapi/IspwRestApiRequest.java
+++ b/src/main/java/com/compuware/ispw/restapi/IspwRestApiRequest.java
@@ -10,15 +10,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.annotation.Nonnull;
-
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import org.kohsuke.stapler.QueryParameter;
-
 import com.cloudbees.plugins.credentials.common.AbstractIdCredentialsListBoxModel;
 import com.cloudbees.plugins.credentials.common.StandardCredentials;
 import com.cloudbees.plugins.credentials.common.StandardListBoxModel;
@@ -42,7 +39,6 @@ import com.compuware.ispw.restapi.util.RestApiUtils;
 import com.compuware.jenkins.common.configuration.HostConnection;
 import com.google.common.base.Strings;
 import com.google.common.collect.Range;
-
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -394,12 +390,6 @@ public class IspwRestApiRequest extends Builder {
 
 		this.url = cesUrl + ispwRequestBean.getContextPath(); // CES URL
 		
-		// Added for the case within BuildTaskAction where some parameters are not required if other parameters are inputed
-		if (this.url.contains("/build?&")) //$NON-NLS-1$
-		{
-			this.url = this.url.replace("/build?&", "/build?"); //$NON-NLS-1$ //$NON-NLS-2$
-		}
-		
 		this.requestBody = ispwRequestBean.getJsonRequest();
 		this.token = cesIspwToken; // CES TOKEN
 
@@ -420,6 +410,14 @@ public class IspwRestApiRequest extends Builder {
 			logger.println();
 		}
 
+		ArrayList<String> variables = RestApiUtils.getVariables(this.url);
+		if (variables.size() != 0)
+		{
+			String errorMsg = "Action failed, need to define the following: " + variables;
+			logger.println(errorMsg);
+			throw new IllegalStateException(new Exception(errorMsg));
+		}
+		
 		for (Map.Entry<String, String> e : build.getBuildVariables().entrySet()) {
 			envVars.put(e.getKey(), e.getValue());
 			

--- a/src/main/java/com/compuware/ispw/restapi/IspwRestApiRequestStep.java
+++ b/src/main/java/com/compuware/ispw/restapi/IspwRestApiRequestStep.java
@@ -441,6 +441,14 @@ public final class IspwRestApiRequestStep extends AbstractStepImpl {
 				logger.println();
 			}
 
+			ArrayList<String> variables = RestApiUtils.getVariables(step.url);
+			if (variables.size() != 0)
+			{
+				String errorMsg = "Action failed, need to define the following: " + variables;
+				logger.println(errorMsg);
+				throw new IllegalStateException(new Exception(errorMsg));
+			}
+			
 			logger.println("Starting ISPW Operations Plugin");
 			action.startLog(logger, ispwRequestBean.getIspwContextPathBean(), ispwRequestBean.getJsonObject());
 

--- a/src/main/java/com/compuware/ispw/restapi/action/BuildTaskAction.java
+++ b/src/main/java/com/compuware/ispw/restapi/action/BuildTaskAction.java
@@ -43,7 +43,13 @@ public class BuildTaskAction extends SetInfoPostAction implements IBuildAction
 	@Override
 	public IspwRequestBean getIspwRequestBean(String srid, String ispwRequestBody, WebhookToken webhookToken)
 	{
-		return getIspwRequestBean(srid, ispwRequestBody, webhookToken, contextPath);
+		IspwRequestBean bean = getIspwRequestBean(srid, ispwRequestBody, webhookToken, contextPath);
+
+		String contextPath = bean.getContextPath();
+		contextPath = contextPath.replaceAll(",", "&taskId=");
+		bean.setContextPath(contextPath);
+
+		return bean;
 	}
 
 	@SuppressWarnings("nls")

--- a/src/main/java/com/compuware/ispw/restapi/action/BuildTaskAction.java
+++ b/src/main/java/com/compuware/ispw/restapi/action/BuildTaskAction.java
@@ -6,7 +6,7 @@
  * All Compuware products listed within the materials are trademarks of Compuware Corporation. All other company or product
  * names are trademarks of their respective owners.
  * 
- * Copyright (c) 2019 Compuware Corporation. All rights reserved.
+ * Copyright (c) 2020 Compuware Corporation. All rights reserved.
  */
 package com.compuware.ispw.restapi.action;
 

--- a/src/main/java/com/compuware/ispw/restapi/action/GenericPostAction.java
+++ b/src/main/java/com/compuware/ispw/restapi/action/GenericPostAction.java
@@ -3,9 +3,7 @@ package com.compuware.ispw.restapi.action;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
-
 import org.apache.commons.lang3.StringUtils;
-
 import com.compuware.ces.communications.service.data.EventCallback;
 import com.compuware.ces.model.BasicAuthentication;
 import com.compuware.ces.model.HttpHeader;
@@ -121,7 +119,6 @@ public abstract class GenericPostAction<T> extends AbstractPostAction {
 			ReflectUtils.reflectSetter(postObject, "eventCallbacks", events);
 		}
 
-		path = path.replaceAll(",", "&taskId=");
 		bean.setContextPath(RestApiUtils.cleanContextPath(path));
 
 		JsonProcessor jsonGenerator = new JsonProcessor();

--- a/src/main/java/com/compuware/ispw/restapi/action/IBuildAction.java
+++ b/src/main/java/com/compuware/ispw/restapi/action/IBuildAction.java
@@ -6,7 +6,7 @@
  * All Compuware products listed within the materials are trademarks of Compuware Corporation. All other company or product
  * names are trademarks of their respective owners.
  * 
- * Copyright (c) 2019 Compuware Corporation. All rights reserved.
+ * Copyright (c) 2020 Compuware Corporation. All rights reserved.
  */
 package com.compuware.ispw.restapi.action;
 
@@ -91,7 +91,12 @@ public interface IBuildAction
 						}
 						if (buildParms.getTaskIds() != null && !buildParms.getTaskIds().isEmpty())
 						{
-							requestBodyBuilder.append("\ntaskId = " + buildParms.getTaskIds().get(0));
+							requestBodyBuilder.append("\ntaskId = ");
+							for (String taskId : buildParms.getTaskIds())
+							{
+								requestBodyBuilder.append(taskId + ",");
+							}
+							requestBodyBuilder.deleteCharAt(requestBodyBuilder.length() - 1); // remove last comma
 						}
 						requestBodyBuilder.append(ispwRequestBody); // the original request body may still contain webhook event
 																	// information.

--- a/src/main/java/com/compuware/ispw/restapi/util/RestApiUtils.java
+++ b/src/main/java/com/compuware/ispw/restapi/util/RestApiUtils.java
@@ -402,6 +402,8 @@ public class RestApiUtils {
 		
 		List<String> queryParams = listQueryParams(contextPath);
 		
+		contextPath = contextPath.replace("?&", "?");
+		
 		int index = contextPath.indexOf("?");
 		if (index != -1) {
 			String s1 = contextPath.substring(0, index);
@@ -422,4 +424,26 @@ public class RestApiUtils {
 		return resultPath;
 	}
 	
+	/**
+	 * Find all variables that match variable name
+	 * 
+	 * @param s
+	 *            the string to extract the variables from
+	 * @return array list of variables
+	 */
+	public static ArrayList<String> getVariables(String s)
+	{
+		String regex = "\\{\\w*\\}";
+		Pattern pattern = Pattern.compile(regex);
+		Matcher matcher = pattern.matcher(s);
+
+		ArrayList<String> vars = new ArrayList<String>();
+		while (matcher.find())
+		{
+			vars.add(matcher.group().replace("{", StringUtils.EMPTY).replace("}", StringUtils.EMPTY));
+		}
+
+		return vars;
+	}
+
 }

--- a/src/test/java/com/compuware/ispw/restapi/util/RestApiUtilsTest.java
+++ b/src/test/java/com/compuware/ispw/restapi/util/RestApiUtilsTest.java
@@ -2,7 +2,7 @@ package com.compuware.ispw.restapi.util;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
+import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.log4j.Logger;
@@ -59,5 +59,16 @@ public class RestApiUtilsTest {
 		logger.info("contextPath=" + contextPath);
 		
 		assertEquals(contextPath, "/ispw/{srid}/assignments/{assignmentId}/tasks/deploy?level=DEV1");
+	}
+	
+	@Test
+	public void testGetVariables()
+	{
+		String contextPath = "/ispw/{srid}/assignments/{assignmentId}/tasks/deploy?level=DEV1&mname={mname}&mtype={mtype}";
+
+		ArrayList<String> variables = RestApiUtils.getVariables(contextPath);
+		logger.info("variables=" + variables);
+
+		assertEquals(variables.size(), 4);
 	}
 }


### PR DESCRIPTION
input 2. move specific build replacement from main thread into
RestApiUtils.cleanContextPath() 3. move replacement of multiple task IDs
to BuildTaskActions from GenericPostAction; - CWE-154835
Jenkins: URISyntaxException occurs executing the build release REST API
call