### PR TITLE
CWE-164968: Pass the git repo URL without escaping it

### DIFF
--- a/src/main/java/com/compuware/ispw/git/CliExecutor.java
+++ b/src/main/java/com/compuware/ispw/git/CliExecutor.java
@@ -1,3 +1,14 @@
+/**
+* THESE MATERIALS CONTAIN CONFIDENTIAL INFORMATION AND TRADE SECRETS OF BMC SOFTWARE, INC. YOU SHALL MAINTAIN THE MATERIALS AS
+* CONFIDENTIAL AND SHALL NOT DISCLOSE ITS CONTENTS TO ANY THIRD PARTY EXCEPT AS MAY BE REQUIRED BY LAW OR REGULATION. USE,
+* DISCLOSURE, OR REPRODUCTION IS PROHIBITED WITHOUT THE PRIOR EXPRESS WRITTEN PERMISSION OF BMC SOFTWARE, INC.
+*
+* ALL BMC SOFTWARE PRODUCTS LISTED WITHIN THE MATERIALS ARE TRADEMARKS OF BMC SOFTWARE, INC. ALL OTHER COMPANY PRODUCT NAMES
+* ARE TRADEMARKS OF THEIR RESPECTIVE OWNERS.
+*
+* (c) Copyright 2020 BMC Software, Inc.
+*/
+
 package com.compuware.ispw.git;
 
 import java.io.IOException;
@@ -74,7 +85,7 @@ public class CliExecutor
 		String host = ArgumentUtils.escapeForScript(connection.getHost());
 		String port = ArgumentUtils.escapeForScript(connection.getPort());
 
-		logger.print(String.format("Using host connection: %s:$s", host, port));
+		logger.println(String.format("Using host connection: %s:%s", host, port));
 		
 		String protocol = connection.getProtocol();
 		String codePage = connection.getCodePage();
@@ -158,7 +169,8 @@ public class CliExecutor
 		args.add(GitToIspwConstants.GIT_USERID_PARAM, gitUserId);
 		args.add(GitToIspwConstants.GIT_PW_PARAM);
 		args.add(gitPassword, true);
-		args.add(GitToIspwConstants.GIT_REPO_URL_PARAM, ArgumentUtils.escapeForScript(gitRepoUrl));
+		// Do not escape the gitRepoUrl as it will not be parsed correctly on the CLI side
+		args.add(GitToIspwConstants.GIT_REPO_URL_PARAM, gitRepoUrl);
 		args.add(GitToIspwConstants.GIT_REF_PARAM, ref);
 		args.add(GitToIspwConstants.GIT_FROM_HASH_PARAM, fromHash);
 		


### PR DESCRIPTION
Minor bugs with storing the git commit information in the ISPW CLI
https://agile.compuware.com/browse/CWE-164968