### PR TITLE
Remove JAXB dependencies for better Java 11 readiness [JENKINS-68457]

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,6 +432,11 @@ information.
 
 # Change Log
 
+## Version 1.0.10
+
+ 🚀 Improvements
+- Support for removal of JAXB and Java 11 requirement (JENKINS-68457).
+
 ## Version 1.0.9
 
  🚀 New features and improvements

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jenkins.version>2.222.4</jenkins.version>
+		<jenkins.version>2.277.4</jenkins.version>
 		<java.level>8</java.level>
 		<maven.test.skip>false</maven.test.skip>
 		<enforcer.skip>true</enforcer.skip>
@@ -426,8 +426,18 @@
 		    <artifactId>matrix-project</artifactId>
 		    <version>1.4</version>
 		</dependency>
-
-
+		
+		<dependency>
+		  <groupId>io.jenkins.plugins</groupId>
+		  <artifactId>jaxb</artifactId>
+		  <version>2.3.6-1</version>
+		</dependency>
+		
+		<dependency>
+		   <groupId>org.slf4j</groupId>
+		   <artifactId>log4j-over-slf4j</artifactId>
+		   <version>1.7.30</version>
+		</dependency>
 	</dependencies>
 
 </project>


### PR DESCRIPTION
Added explicit dependency on JAXB plugin as suggested by Jenkins https://issues.jenkins.io/browse/JENKINS-68457

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
